### PR TITLE
Fix erroneous 'use 5.008' in Makefile.PL

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -22,7 +22,11 @@ remove = PerlIO
 remove = PerlIO::scalar
 remove = Test::Differences
 remove = Inline
+; tests optionally require 5.008
+remove = perl
 
 [Prereqs / TestRecommends]
 Inline = 0.50
 
+[Prereqs]
+perl = 5.006


### PR DESCRIPTION
Dist::Zilla::Plugin::MinimumPerl was picking up 5.8-isms, but they are
all optional and guarded, so override it down to 5.006
