### PR TITLE
Recommend Inline::C, not just Inline.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -24,7 +24,7 @@ remove = Inline
 remove = perl
 
 [Prereqs / TestRecommends]
-Inline = 0.50
+Inline::C = 0.50
 
 [Prereqs]
 perl = 5.006


### PR DESCRIPTION
Otherwise, if you have Inline but not Inline::C, you get an error like this:

```
t/19-inline-c.t ............ Error. You have specified 'C' as an Inline programming language.

I currently only know about the following languages:
    Foo, foo

If you have installed a support module for this language, try deleting the
config-x86_64-linux-thread-multi-5.020000 file from the following Inline DIRECTORY, and run again:

    /home/dwheeler/iov-perl/BUILD/Capture-Tiny-0.24/_Inline

(And if that works, please file a bug report.)

 at t/19-inline-c.t line 15.
t/19-inline-c.t ............ Dubious, test returned 255 (wstat 65280, 0xff00)
```
