### PR TITLE
Treat Cygwin like MSWin32 during tests

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,11 @@ Revision history for Capture-Tiny
 
 {{$NEXT}}
 
+0.31      2015-07-12 15:23:00-04:00 America/New_York
+  Tests:
+
+  - Fix tests on Cygwin platform.  Handle as if MSWin32 is set.
+
 0.30      2015-05-15 20:43:54-04:00 America/New_York
 
   No changes from 0.29

--- a/t/03-tee.t
+++ b/t/03-tee.t
@@ -12,7 +12,7 @@ use Utils qw/next_fd/;
 use Cases qw/run_test/;
 
 use Config;
-my $no_fork = $^O ne 'MSWin32' && ! $Config{d_fork};
+my $no_fork = ($^O ne 'MSWin32' || $^O ne 'Cygwin') && ! $Config{d_fork};
 if ( $no_fork ) {
   plan skip_all => 'tee() requires fork';
 }

--- a/t/06-stdout-closed.t
+++ b/t/06-stdout-closed.t
@@ -12,7 +12,7 @@ use Utils qw/save_std restore_std next_fd/;
 use Cases qw/run_test/;
 
 use Config;
-my $no_fork = $^O ne 'MSWin32' && ! $Config{d_fork};
+my $no_fork = ($^O ne 'MSWin32' || $^O ne 'Cygwin') && ! $Config{d_fork};
 
 plan 'no_plan';
 

--- a/t/07-stderr-closed.t
+++ b/t/07-stderr-closed.t
@@ -12,7 +12,7 @@ use Utils qw/save_std restore_std next_fd/;
 use Cases qw/run_test/;
 
 use Config;
-my $no_fork = $^O ne 'MSWin32' && ! $Config{d_fork};
+my $no_fork = ($^O ne 'MSWin32' || $^O ne 'Cygwin') && ! $Config{d_fork};
 
 plan 'no_plan';
 

--- a/t/08-stdin-closed.t
+++ b/t/08-stdin-closed.t
@@ -12,7 +12,7 @@ use Utils qw/save_std restore_std next_fd/;
 use Cases qw/run_test/;
 
 use Config;
-my $no_fork = $^O ne 'MSWin32' && ! $Config{d_fork};
+my $no_fork = ($^O ne 'MSWin32' || $^O ne 'Cygwin') && ! $Config{d_fork};
 
 plan 'no_plan';
 

--- a/t/10-stdout-string.t
+++ b/t/10-stdout-string.t
@@ -12,7 +12,7 @@ use Utils qw/save_std restore_std next_fd/;
 use Cases qw/run_test/;
 
 use Config;
-my $no_fork = $^O ne 'MSWin32' && ! $Config{d_fork};
+my $no_fork = ($^O ne 'MSWin32' || $^O ne 'Cygwin') && ! $Config{d_fork};
 
 plan skip_all => "In memory files require Perl 5.8"
   if $] < 5.008;

--- a/t/11-stderr-string.t
+++ b/t/11-stderr-string.t
@@ -12,7 +12,7 @@ use Utils qw/save_std restore_std next_fd/;
 use Cases qw/run_test/;
 
 use Config;
-my $no_fork = $^O ne 'MSWin32' && ! $Config{d_fork};
+my $no_fork = ($^O ne 'MSWin32' || $^O ne 'Cygwin') && ! $Config{d_fork};
 
 plan skip_all => "In memory files require Perl 5.8"
   if $] < 5.008;

--- a/t/12-stdin-string.t
+++ b/t/12-stdin-string.t
@@ -12,7 +12,7 @@ use Utils qw/save_std restore_std next_fd/;
 use Cases qw/run_test/;
 
 use Config;
-my $no_fork = $^O ne 'MSWin32' && ! $Config{d_fork};
+my $no_fork = ($^O ne 'MSWin32' || $^O ne 'Cygwin') && ! $Config{d_fork};
 
 plan skip_all => "In memory files require Perl 5.8"
   if $] < 5.008;

--- a/t/13-stdout-tied.t
+++ b/t/13-stdout-tied.t
@@ -13,7 +13,7 @@ use Cases qw/run_test/;
 use TieLC;
 
 use Config;
-my $no_fork = $^O ne 'MSWin32' && ! $Config{d_fork};
+my $no_fork = ($^O ne 'MSWin32' || $^O ne 'Cygwin') && ! $Config{d_fork};
 
 plan skip_all => "capture needs Perl 5.8 for tied STDOUT"
   if $] < 5.008;

--- a/t/14-stderr-tied.t
+++ b/t/14-stderr-tied.t
@@ -13,7 +13,7 @@ use Cases qw/run_test/;
 use TieLC;
 
 use Config;
-my $no_fork = $^O ne 'MSWin32' && ! $Config{d_fork};
+my $no_fork = ($^O ne 'MSWin32' || $^O ne 'Cygwin') && ! $Config{d_fork};
 
 plan skip_all => "capture needs Perl 5.8 for tied STDERR"
   if $] < 5.008;

--- a/t/15-stdin-tied.t
+++ b/t/15-stdin-tied.t
@@ -13,7 +13,7 @@ use Cases qw/run_test/;
 use TieLC;
 
 use Config;
-my $no_fork = $^O ne 'MSWin32' && ! $Config{d_fork};
+my $no_fork = ($^O ne 'MSWin32' || $^O ne 'Cygwin') && ! $Config{d_fork};
 
 plan skip_all => "capture needs Perl 5.8 for tied STDERR"
   if $] < 5.008;

--- a/t/20-stdout-badtie.t
+++ b/t/20-stdout-badtie.t
@@ -13,7 +13,7 @@ use Cases qw/run_test/;
 use TieEvil;
 
 use Config;
-my $no_fork = $^O ne 'MSWin32' && ! $Config{d_fork};
+my $no_fork = ($^O ne 'MSWin32' || $^O ne 'Cygwin') && ! $Config{d_fork};
 
 plan skip_all => "capture needs Perl 5.8 for tied STDOUT"
   if $] < 5.008;

--- a/t/21-stderr-badtie.t
+++ b/t/21-stderr-badtie.t
@@ -13,7 +13,7 @@ use Cases qw/run_test/;
 use TieEvil;
 
 use Config;
-my $no_fork = $^O ne 'MSWin32' && ! $Config{d_fork};
+my $no_fork = ($^O ne 'MSWin32' || $^O ne 'Cygwin') && ! $Config{d_fork};
 
 plan skip_all => "capture needs Perl 5.8 for tied STDERR"
   if $] < 5.008;

--- a/t/22-stdin-badtie.t
+++ b/t/22-stdin-badtie.t
@@ -13,7 +13,7 @@ use Cases qw/run_test/;
 use TieEvil;
 
 use Config;
-my $no_fork = $^O ne 'MSWin32' && ! $Config{d_fork};
+my $no_fork = ($^O ne 'MSWin32' || $^O ne 'Cygwin') && ! $Config{d_fork};
 
 plan skip_all => "capture needs Perl 5.8 for tied STDIN"
   if $] < 5.008;

--- a/t/23-all-tied.t
+++ b/t/23-all-tied.t
@@ -13,7 +13,7 @@ use Cases qw/run_test/;
 use TieLC;
 
 use Config;
-my $no_fork = $^O ne 'MSWin32' && ! $Config{d_fork};
+my $no_fork = ($^O ne 'MSWin32' || $^O ne 'Cygwin') && ! $Config{d_fork};
 
 plan skip_all => "capture needs Perl 5.8 for tied STDOUT"
   if $] < 5.008;

--- a/t/24-all-badtied.t
+++ b/t/24-all-badtied.t
@@ -13,7 +13,7 @@ use Cases qw/run_test/;
 use TieEvil;
 
 use Config;
-my $no_fork = $^O ne 'MSWin32' && ! $Config{d_fork};
+my $no_fork = ($^O ne 'MSWin32' || $^O ne 'Cygwin') && ! $Config{d_fork};
 
 plan skip_all => "capture needs Perl 5.8 for tied STDIN"
   if $] < 5.008;


### PR DESCRIPTION
Installation issues on Cygwin x86_64 looks to be due to how tests are handling forking.  Cygwin has quirks when forking so tests have been updated to not perform forking.  Tests now pass on my machine.  YMMV.