### PR TITLE
Do not try to restore what we didn't save earlier

### DIFF
--- a/t/12-stdin-string.t
+++ b/t/12-stdin-string.t
@@ -53,7 +53,7 @@ if ( ! $no_fork ) {
 }
 
 is( next_fd, $fd, "no file descriptors leaked" );
-restore_std(qw/stdout/);
+restore_std(qw/stdin/);
 
 exit 0;
 


### PR DESCRIPTION
This is the most minimal fix for https://github.com/dagolden/Capture-Tiny/issues/22. The minimal reproduction on any 5.8.x is:

```
$ perl -It/lib -MUtils -e 'save_std("stdin"); restore_std("stdout")' < /dev/null
```

It fails due to how the "never saved restore" behaves given differences in autovivification. I think the real problem is that it is silent on 5.10+ and the real fix is to make sure restore_std croaks when trying to restore things it never saved in the first place.

Feel free to reject this PR and implement the more involved fix.
