### PR TITLE
avoid shadowing variable in _relayer

### DIFF
--- a/lib/Capture/Tiny.pm
+++ b/lib/Capture/Tiny.pm
@@ -81,7 +81,7 @@ HERE
 #--------------------------------------------------------------------------#
 
 sub _relayer {
-  my ($fh, $layers) = @_;
+  my ($fh, $apply_layers) = @_;
   # _debug("# requested layers (@{$layers}) for @{[fileno $fh]}\n");
 
   # eliminate pseudo-layers
@@ -91,7 +91,7 @@ sub _relayer {
       binmode( $fh, ":pop" );
   }
   # apply other layers
-  my @to_apply = @$layers;
+  my @to_apply = @$apply_layers;
   shift @to_apply; # eliminate initial :unix
   # _debug("# applying layers  (unix @to_apply) to @{[fileno $fh]}\n");
   binmode($fh, ":" . join(":",@to_apply));


### PR DESCRIPTION
Use a different variable name for the layers to apply from the layers
being removed in _relayer.  This makes the code more readable.

As a side benefit, it avoids a bug in Devel::CallParser that will break
the shadowed variable on threaded perls.