### PR TITLE
 fix string comparisons with $] to use numeric comparison instead

### DIFF
--- a/t/08-stdin-closed.t
+++ b/t/08-stdin-closed.t
@@ -17,7 +17,7 @@ my $no_fork = $^O ne 'MSWin32' && ! $Config{d_fork};
 plan 'no_plan';
 
 my $builder = Test::More->builder;
-binmode($builder->failure_output, ':utf8') if $] >= 5.008;
+binmode($builder->failure_output, ':utf8') if "$]" >= 5.008;
 
 # XXX work around a bug in perl; this needs to be called early-ish
 # to avoid some sort of filehandle leak when combined with Capture::Tiny
@@ -39,7 +39,7 @@ run_test($_) for qw(
 if ( ! $no_fork ) {
   # prior to 5.12, PERL_UNICODE=D causes problems when STDIN is closed
   # before capturing.  No idea why.  Documented as a known issue.
-  if ( $] lt '5.012' && ${^UNICODE} & 24 ) {
+  if ( "$]" < 5.012 && ${^UNICODE} & 24 ) {
     diag 'Skipping tee() tests because PERL_UNICODE=D not supported';
   }
   else {
@@ -53,7 +53,7 @@ if ( ! $no_fork ) {
   }
 }
 
-if ( $] lt '5.012' && ${^UNICODE} & 24 ) {
+if ( "$]" < 5.012 && ${^UNICODE} & 24 ) {
   diag 'Skipping leak test because PERL_UNICODE=D not supported';
 }
 else {

--- a/t/lib/Cases.pm
+++ b/t/lib/Cases.pm
@@ -57,7 +57,7 @@ sub _restore_layers {
 my %texts = (
   short => 'Hello World',
   multiline => 'First line\nSecond line\n',
-  ( $] lt "5.008" ? () : ( unicode => 'Hi! \x{263a}\n') ),
+  ( "$]" < 5.008 ? () : ( unicode => 'Hi! \x{263a}\n') ),
 );
 
 #--------------------------------------------------------------------------#


### PR DESCRIPTION
The fix follows Zefram's suggestion from
https://www.nntp.perl.org/group/perl.perl5.porters/2012/05/msg186846.html

    On older perls, however, $] had a numeric value that was built up using
    floating-point arithmetic, such as 5+0.006+0.000002. This would not
    necessarily match the conversion of the complete value from string form
    [perl #72210]. You can work around that by explicitly stringifying
    $] (which produces a correct string) and having that numify (to a
    correctly-converted floating point value) for comparison. I cultivate
    the habit of always stringifying $] to work around this, regardless of
    the threshold where the bug was fixed. So I'd write

    use if "$]" >= 5.014, warnings => "non_unicode";

This ensures that the comparisons will still work when Perl's major version changes to anything greater than 9.